### PR TITLE
Fix urlEncode

### DIFF
--- a/src/utils/Http.ts
+++ b/src/utils/Http.ts
@@ -3,7 +3,11 @@ export function urlEncode(obj: {}): string {
     const str = [];
     Object.keys(obj).forEach((p) => {
         if (obj.hasOwnProperty(p)) {
-            str.push(typeof obj[p] === 'object' ? urlEncode(obj[p]) : encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]));
+            if (typeof obj[p] === 'object') {
+                str.push(encodeURIComponent(p) + '=' + encodeURIComponent(JSON.stringify(obj[p])));
+            } else {
+                str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]));
+            }
         }
     });
     return str.join('&');

--- a/test/utils/HttpTest.ts
+++ b/test/utils/HttpTest.ts
@@ -1,0 +1,23 @@
+import {urlEncode} from '../../src/utils/Http';
+
+describe('utils.Http', () => {
+    
+    describe('#limitpage', () => {
+        const obj = { limit: 10, page: 1 };
+
+        it('urlEncode', (done) => {
+            expect(urlEncode(obj)).to.be.eq('limit=10&page=1');
+            done();
+        });
+    });
+
+    describe('#query', () => {
+        const obj = { query: {"timestamp":{"$gt":1519084800000}}, limit: 10000 };
+
+        it('urlEncode', (done) => {
+            expect(urlEncode(obj)).to.be.eq('query=%7B%22timestamp%22%3A%7B%22%24gt%22%3A1519084800000%7D%7D&limit=10000');
+            done();
+        });
+    });
+
+});


### PR DESCRIPTION
Before:

```
  1) utils.Http #query urlEncode:

      AssertionError: expected '%24gt=1519084800000&limit=10000' to equal 'query=%7B%22timestamp%22%3A%7B%22%24gt%22%3A1519084800000%7D%7D&limit=10000'
      + expected - actual

      -%24gt=1519084800000&limit=10000
      +query=%7B%22timestamp%22%3A%7B%22%24gt%22%3A1519084800000%7D%7D&limit=10000

      at Context.<anonymous> (test/utils/HttpTest.js:14:49)
```